### PR TITLE
Add warning for misaligned JSX closing tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brigade",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Brigade's ESLint configuration",
   "main": "index.js",
   "scripts": {

--- a/react.js
+++ b/react.js
@@ -15,9 +15,7 @@ module.exports = {
     'react/display-name': 0,
     'react/forbid-prop-types': 0,
     'react/jsx-boolean-value': [2, 'never'],
-    'react/jsx-closing-bracket-location': [1, {
-      selfClosing: 'tag-aligned', nonEmpty: 'props-aligned'
-    }],
+    'react/jsx-closing-bracket-location': [1, 'tag-aligned'],
     'react/jsx-curly-spacing': [2, 'never'],
     'react/jsx-indent-props': [2, 2],
     'react/jsx-max-props-per-line': 0,

--- a/react.js
+++ b/react.js
@@ -15,6 +15,9 @@ module.exports = {
     'react/display-name': 0,
     'react/forbid-prop-types': 0,
     'react/jsx-boolean-value': [2, 'never'],
+    'react/jsx-closing-bracket-location': [1, {
+      selfClosing: 'tag-aligned', nonEmpty: 'props-aligned'
+    }],
     'react/jsx-curly-spacing': [2, 'never'],
     'react/jsx-indent-props': [2, 2],
     'react/jsx-max-props-per-line': 0,


### PR DESCRIPTION
Kevin just called me out for this style infraction. I'd like our tooling
to call me out in the future, since Kevin is far too busy to always be
watching. :eyes:

But on a serious note, I believe it is the role of tools like eslint to
remove as much subjectivity from our code review process as possible. I
was pleasantly surprised to find this linting option as a viable way to
enforce the rule that Kevin suggested.

Examples of how to do it:

``` jsx
<Hello shortProp="bar" />

<Hello
  veryLongPropName="bar"
/>

<Hello
  foo="bar"
>
  <p>...</p>
</Hello>
```

This is consistent with AirBnB's [style guide for the same](https://github.com/airbnb/javascript/tree/062929ee5f5ca368b2b36390fc36aed34ed96797/react#alignment).
