### PR TITLE
Standardize on spaces inside curlies

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = {
     'guard-for-in': 2,
     'indent': [2, 2, { 'SwitchCase': 1 }],
     'jsx-quotes': [2, 'prefer-single'],
+    'object-curly-spacing': [1, 'always'],
     'key-spacing': 0,
     'keyword-spacing': 2,
     'max-len': [1, 80, 2],


### PR DESCRIPTION
We have 1900 instances of spaces inside curlies, to only 155 instances
of curlies without spaces.

$ ag --js '{[ ]+[^ ]+:[^}]+}' | wc -l
1900

$ ag --js '{[^ ]+:[^}]+}' | wc -l
155

In the spirit of there being no ambiguity about the right way to do
things and reducing style comments in code review, this enables
"object-curly-spacing: always" at the warning level.

[Airbnb also does this.](https://github.com/airbnb/javascript#whitespace--in-braces)
