### PR TITLE
Standardize on no spaces inside arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
   },
 
   'rules': {
+    'array-bracket-spacing': [1, 'never'],
     'block-scoped-var': 0,
     'brace-style': [2, '1tbs', { 'allowSingleLine': false }],
     'camelcase': [2, { 'properties': 'never' }],


### PR DESCRIPTION
We have 2266 instances of arrays without spaces, to only 19 instances
of arrays with spaces.

$ ag --js '[[^\n]]+]' | wc -l
2266

$ ag --js '[ [^\n]]+]' | wc -l
19

(the first is a pretty bad regex, lots of false positives, but is still
way more than 19)

In the spirit of there being no ambiguity about the right way to do
things and reducing style comments in code review, this enables
"array-bracket-spacing: never" at the warning level.

[Airbnb also does this.](https://github.com/airbnb/javascript#whitespace--in-brackets)
