### PR TITLE
Set max-len to error at 100 characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = {
     'object-curly-spacing': [1, 'always'],
     'key-spacing': 0,
     'keyword-spacing': 2,
-    'max-len': [1, 80, 2],
+    'max-len': [2, 100, 2],
     'max-nested-callbacks': [2, 3],
     'max-params': [1, 4],
     'new-cap': [2, { 'newIsCap': true, 'capIsNew': false }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brigade",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Brigade's ESLint configuration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As decided at the 2016-04-25 Web Working Group[1](https://docs.google.com/document/d/1qBH49rV66kPNrKGvrsipIEMAeJUXb6xfNLaRnoH9LoY/edit), we have consensus to
make two changes to our line-length rules:

1) Lines can be up to 100 characters (warn at 80)
2) 100 characters is a hard limit

Unfortunately, eslint doesn't appear to support simultaneous "warn at
80" and "error at 100" declarations, so I've decided to just bump up the
limit to 100 characters and rely on our vim/emacs/sublime configs to set
colorcolumns at the appropriate places for visual feedback as we
approach the line length limit.
