### PR TITLE
Ignore comments and URLs in max-len calculation

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = {
     'object-curly-spacing': [1, 'always'],
     'key-spacing': 0,
     'keyword-spacing': 2,
-    'max-len': [2, 100, 2],
+    'max-len': [2, { 'code': 100, 'ignoreComments': true, 'ignoreUrls': true }],
     'max-nested-callbacks': [2, 3],
     'max-params': [1, 4],
     'new-cap': [2, { 'newIsCap': true, 'capIsNew': false }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brigade",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Brigade's ESLint configuration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We have a number of lines like:

// @see {long url here}

This does not contribute negatively to poor readability of source code
since it is a comment, so I argue it should be permitted.
