### PR TITLE
Raise error if file does not end with a unix newline

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
     'consistent-return': 0,
     'curly': 2,
     'dot-notation': 2,
+    'eol-last': [2, 'unix'],
     'eqeqeq': 2,
     'guard-for-in': 2,
     'indent': [2, 2, { 'SwitchCase': 1 }],


### PR DESCRIPTION
Lately we have been getting some diffs between different editor
configurations that do/don't automatically put a newline at the end of a
file.

There are some good reasons for always ending files with a newline:
- Some programming languages require it, therefore it is likely to be
  already an editor default.
- It helps git with diffing
- When cat-ing a file in bash, your prompt won't get stuck to the end of
  the file

...and no reasons against it that I can think of.

To comply, make sure that:
- (vim) `eol` is set (no action is required; it is set by default)
- (sublime) `ensure_newline_at_eof_on_save` is set to true in
  preferences. See:
  https://forum.sublimetext.com/t/make-saving-newline-at-eof-the-installation-default/9842
