### PR TITLE
Support eslint-plugin-react v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brigade",
-  "version": "2.0.8",
+  "version": "3.0.0",
   "description": "Brigade's ESLint configuration",
   "main": "index.js",
   "scripts": {

--- a/react.js
+++ b/react.js
@@ -25,7 +25,7 @@ module.exports = {
     'react/jsx-pascal-case': 2,
     'react/jsx-uses-react': 1,
     'react/jsx-uses-vars': 1,
-    'react/no-did-mount-set-state': [1, 'allow-in-func'],
+    'react/no-did-mount-set-state': 1,
     'react/no-did-update-set-state': 1,
     'react/no-multi-comp': 1,
     'react/no-unknown-property': 2,


### PR DESCRIPTION
Updates `react/no-did-mount-set-state` to match the changes introduced in [`eslint-plugin-react v6.0.0.`](https://github.com/yannickcr/eslint-plugin-react/blob/976b9d2d898e761f3184febffb60380d6addf238/CHANGELOG.md#600---2016-08-01) 

This is a breaking change, so the package version has been bumped as well.
