### PR TITLE
Renamed react/wrap-muiltilines to react/jsx-wrap-multilines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brigade",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Brigade's ESLint configuration",
   "main": "index.js",
   "scripts": {

--- a/react.js
+++ b/react.js
@@ -25,6 +25,7 @@ module.exports = {
     'react/jsx-pascal-case': 2,
     'react/jsx-uses-react': 1,
     'react/jsx-uses-vars': 1,
+    'react/jsx-wrap-multilines': 2,
     'react/no-did-mount-set-state': 1,
     'react/no-did-update-set-state': 1,
     'react/no-multi-comp': 1,
@@ -33,6 +34,5 @@ module.exports = {
     'react/react-in-jsx-scope': 1,
     'react/self-closing-comp': 2,
     'react/sort-comp': 2,
-    'react/wrap-multilines': 2,
   }
 };


### PR DESCRIPTION
Renamed `react/wrap-muiltilines` to `react/jsx-wrap-multilines`. This fixes a deprecation warning introduced in [`eslint-plugin-react v6.0.0`](https://github.com/yannickcr/eslint-plugin-react/blob/976b9d2d898e761f3184febffb60380d6addf238/CHANGELOG.md#600---2016-08-01)

Deprecation warning:

> The react/wrap-multilines rule is deprecated. Please use the react/jsx-wrap-multilines rule instead.
