### PR TITLE
Forbid global "event" variable in event handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ module.exports = {
     'no-proto': 2,
     'no-redeclare': 2,
     'no-regex-spaces': 2,
+    'no-restricted-globals': [2, 'event'],
     'no-return-assign': 0,
     'no-script-url': 2,
     'no-self-compare': 2,


### PR DESCRIPTION
Today I learned that WebKit and IE provide a global "event" variable in
event handlers. This means that code like:

``` javascript
function handleClick() {
  $(event.target).hide();
}
```

will work in those browsers. Not in firefox though.

I haven't yet seen an instance of this code in brigade, but I was
surprised that eslint is cool with "event" being an implicit global
variable.

This commit restricts the global so that an reference to a
non-locally-scoped "event" variable is an error. (Note that you can
still do `const event = [...]` since that is in the local scope, not the
global scope.)
