### PR TITLE
Turn on object-shorthand for properties too

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports = {
     'no-var': 2,
     'no-void': 2,
     'no-with': 2,
-    'object-shorthand': [2, 'methods'],
+    'object-shorthand': [2, 'always'],
     'operator-assignment': [2, 'always'],
     'operator-linebreak': [2, 'after'],
     'padded-blocks': [2, 'never'],


### PR DESCRIPTION
I'm running a jscodemod script on our Brigade app codebase to make it
use object shorthand syntax whenever possible. It would be nice to have
eslint help us with this going forward.
