### PR TITLE
Add warnings for import/export modules style rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ module.exports = {
     'node': true
   },
 
+  'plugins': [
+    'import',
+  ],
+
   'rules': {
     'array-bracket-spacing': [1, 'never'],
     'block-scoped-var': 0,
@@ -23,6 +27,12 @@ module.exports = {
     'guard-for-in': 2,
     'indent': [2, 2, { 'SwitchCase': 1 }],
     'jsx-quotes': [2, 'prefer-single'],
+    'import/prefer-default-export': 1,
+    'import/named': 1,
+    'import/newline-after-import': 1,
+    'import/no-duplicates': 1,
+    'import/no-mutable-exports': 1,
+    'import/imports-first': 1,
     'object-curly-spacing': [1, 'always'],
     'key-spacing': 0,
     'keyword-spacing': 2,

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "bugs": {
     "url": "https://github.com/brigade/eslint-config-brigade/issues"
   },
-  "homepage": "https://github.com/brigade/eslint-config-brigade#readme"
+  "homepage": "https://github.com/brigade/eslint-config-brigade#readme",
+  "dependencies": {
+    "eslint-plugin-import": "^2.2.0"
+  }
 }


### PR DESCRIPTION
Based largely on [Airbnb's style rules for modules](http://airbnb.io/javascript/#modules), these warnings check for patterns in module `import`/`export` behavior that could lead to unexpected behavior.

Read about the rules here:
- [prefer-default-export](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md)
- [named](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md)
- [newline-after-import](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md)
- [no-duplicates](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md)
- [no-mutable-exports](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md)
- [imports-first](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/imports-first.md)

These should be changed from warnings to errors once projects are in
compliance.