### PR TITLE
Ensure all dependencies are specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "homepage": "https://github.com/brigade/eslint-config-brigade#readme",
   "dependencies": {
-    "eslint-plugin-import": "^2.2.0"
+    "eslint": "^3.16.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-react": "^6.10.0"
   }
 }


### PR DESCRIPTION
This ensures that all dependencies for the package are explicitly
defined. This means the package can now be used stand-alone, and
can be used in 3rd party packaged without them needing to have/add
our dependencies.