### PR TITLE
Add `peerDependencies` to the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/brigade/eslint-config-brigade#readme",
   "dependencies": {
-    "eslint": "^3.16.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,5 +24,10 @@
     "eslint": "^3.16.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "^6.10.0"
+  },
+  "peerDependencies": {
+    "eslint": "^3.16.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-react": "^6.10.0"
   }
 }


### PR DESCRIPTION
For `eslint`, this makes sense since this package cannot be used outside the context of an ESLint environment.

For the two plugins, their inclusion is to support users using npm2, which unlike npm3 and above can fail to resolve certain dependencies specified here if they are also specified in other parts of the parent package. These will be removed from `peerDependencies` in version 4 of this package.