### PR TITLE
Version change to v3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-brigade",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Brigade's ESLint configuration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This creates patch version 3.2.1 from 3.2.0. This version fixes
issues with npm2 failing to install dependencies in some cases.