### PR TITLE
react/jsx-first-prop-new-line bug fix

### DIFF
--- a/react.js
+++ b/react.js
@@ -24,7 +24,7 @@ module.exports = {
     'react/jsx-closing-bracket-location': 2,
     'react/jsx-curly-spacing': 2,
     'react/jsx-equals-spacing': 2,
-    'react/jsx-first-prop-new-line': [2, { multiline: true }],
+    'react/jsx-first-prop-new-line': [2, 'multiline'],
     'react/jsx-indent': [2, 2],
     'react/jsx-indent-props': [2, 2],
     'react/jsx-max-props-per-line': [2, { maximum: 1, when: 'multiline' }],


### PR DESCRIPTION
The option value for this rule was incorrectly specified as an
object with a boolean key/value, rather than a string. This has
been corrected.