### PR TITLE
Forbid `class` props in react

### DIFF
--- a/react.js
+++ b/react.js
@@ -18,7 +18,7 @@ module.exports = {
   rules: {
     'react/default-props-match-prop-types': 2,
     'react/display-name': 1,
-    'react/forbid-component-props': 0, // TODO: we are discussing this
+    'react/forbid-component-props': [2, { forbid: ['class'] }],
     'react/forbid-elements': 0,
     'react/forbid-foreign-prop-types': 2,
     'react/forbid-prop-types': 2,


### PR DESCRIPTION
In the past, we've had a custom overcommit hook protecting against using
`class` instead of `className` as a prop. For React newcomers, this is a
common mistake to make, so it's good to have some protection in place.
Instead of the custom overcommit hook, we can instead just prevent this
through the react/forbid-component-props rule [1].

[1] https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-component-props.md