### PR TITLE
Add a node entry point

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: [
+    './index.js',
+  ],
+
+  rules: {
+    'no-buffer-constructor': 2,
+  },
+};


### PR DESCRIPTION
This adds a node entry point into the config. This is for applications
that use Node.js but don't use React, such as many of Brigade's servers.