### PR TITLE
Update eslint-plugin-jsx-a11y and declare all rule usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/brigade/eslint-config-brigade#readme",
   "dependencies": {
     "eslint-plugin-import": "^2.3.0",
-    "eslint-plugin-jsx-a11y": "^5.0.3",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0"
   },
   "peerDependencies": {

--- a/react.js
+++ b/react.js
@@ -1,7 +1,6 @@
 module.exports = {
   extends: [
     './index.js',
-    'plugin:jsx-a11y/recommended',
   ],
 
   plugins: [
@@ -16,6 +15,38 @@ module.exports = {
   },
 
   rules: {
+    'jsx-a11y/accessible-emoji': 2,
+    'jsx-a11y/alt-text': 2,
+    'jsx-a11y/anchor-has-content': 2, // NOTE: We recommend customizing this for your app. https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/v6.0.2/docs/rules/anchor-has-content.md
+    'jsx-a11y/anchor-is-valid': 1, // Nice to make this a 2, but this leaves the library config more flexible
+    'jsx-a11y/aria-activedescendant-has-tabindex': 2,
+    'jsx-a11y/aria-props': 2,
+    'jsx-a11y/aria-proptypes': 2,
+    'jsx-a11y/aria-role': [2, { ignoreNonDOM: true }],
+    'jsx-a11y/aria-unsupported-elements': 2,
+    'jsx-a11y/click-events-have-key-events': 1, // TODO: will be moved to a 2 once Brigade has updated our code
+    'jsx-a11y/heading-has-content': 2, // NOTE: We recommend customizing this for your app. https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/v6.0.2/docs/rules/heading-has-content.md
+    'jsx-a11y/html-has-lang': 2,
+    'jsx-a11y/iframe-has-title': 2,
+    'jsx-a11y/img-redundant-alt': 1,
+    'jsx-a11y/interactive-supports-focus': 1, // TODO: will be moved to a 2 once Brigade has updated our code
+    'jsx-a11y/label-has-for': 2, // NOTE: We recommend customizing this for your app. https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/v6.0.2/docs/rules/label-has-for.md
+    'jsx-a11y/lang': 2,
+    'jsx-a11y/media-has-caption': 2, // NOTE: We recommend customizing this for your app. https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/v6.0.2/docs/rules/media-has-caption.md
+    'jsx-a11y/mouse-events-have-key-events': 2,
+    'jsx-a11y/no-access-key': 2,
+    'jsx-a11y/no-autofocus': 2, // NOTE: In the rare case that you actually need this (ex. Google home page search bar autofocus), use a local override
+    'jsx-a11y/no-distracting-elements': 2,
+    'jsx-a11y/no-interactive-element-to-noninteractive-role': 2,
+    'jsx-a11y/no-noninteractive-element-handlers': 2,
+    'jsx-a11y/no-noninteractive-element-to-interactive-role': 2,
+    'jsx-a11y/no-noninteractive-tabindex': 2,
+    'jsx-a11y/no-onchange': 2,
+    'jsx-a11y/no-redundant-roles': 2,
+    'jsx-a11y/no-static-element-interactions': 1, // TODO: will be moved to a 2 once Brigade has updated our code
+    'jsx-a11y/role-has-required-aria-props': 1, // TODO: will be moved to a 2 once Brigade has updated our code
+    'jsx-a11y/scope': 2,
+    'jsx-a11y/tabindex-no-positive': 2,
     'react/default-props-match-prop-types': 2,
     'react/display-name': 1,
     'react/forbid-component-props': 0, // TODO: we are discussing this

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-aria-query@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.5.0.tgz#85e3152cd8cc5bab18dbed61cd9c4fce54fa79c3"
+aria-query@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.0.tgz#4af10a1e61573ddea0cf3b99b51c52c05b424d24"
   dependencies:
     ast-types-flow "0.0.7"
 
@@ -86,8 +86,8 @@ doctrine@^2.0.0:
     isarray "^1.0.0"
 
 emoji-regex@^6.1.0:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.4.2.tgz#a30b6fee353d406d96cfb9fa765bdc82897eff6e"
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
 
 error-ex@^1.2.0:
   version "1.3.1"
@@ -96,13 +96,14 @@ error-ex@^1.2.0:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.0.tgz#3b00385e85729932beffa9163bbea1234e932914"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.0"
+    has "^1.0.1"
     is-callable "^1.1.3"
-    is-regex "^1.0.3"
+    is-regex "^1.0.4"
 
 es-to-primitive@^1.1.1:
   version "1.1.1"
@@ -142,11 +143,11 @@ eslint-plugin-import@^2.3.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-jsx-a11y@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.0.3.tgz#4a939f76ec125010528823331bf948cc573380b6"
+eslint-plugin-jsx-a11y@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.2.tgz#659277a758b036c305a7e4a13057c301cd3be73f"
   dependencies:
-    aria-query "^0.5.0"
+    aria-query "^0.7.0"
     array-includes "^3.0.3"
     ast-types-flow "0.0.7"
     axobject-query "^0.1.0"
@@ -219,7 +220,7 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
-is-regex@^1.0.3:
+is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:


### PR DESCRIPTION
This updates us to the latest version of the
eslint-plugin-jsx-a11y package, v6.0.2. This comes with some
updates and changes, including some breaking ones. Fuurther, as
part of this commit, we have switched from using the recommended
rule set to instead declaring the use of each rule explicitly.